### PR TITLE
improving set_cookie security

### DIFF
--- a/flask_mab/__init__.py
+++ b/flask_mab/__init__.py
@@ -173,7 +173,8 @@ class BanditMiddleware(object):
 
             response.set_cookie(
                     app.extensions['mab'].cookie_name,
-                    json.dumps(request.bandits))
+                    json.dumps(request.bandits),
+                    secure=True, httponly=True, samesite='Lax')
             return response
 
         @app.after_request


### PR DESCRIPTION
Hi Mark,

We have a free program analysis tool for Python based web projects, called Bento. While we were scanning GitHub projects for issues, it triggered a warning for cookie security best practices for your app.

I don't think there is a major security issue with the way you call`resp.set_cookie()` in flask_mab/__init__.py:174. But I thought there is no harm in setting the `secure`, `httponly` and `samesite` parameters according to Flask cookie security practices (https://flask.palletsprojects.com/en/1.1.x/security/#set-cookie-options). This MSFT article has some additional explanations on XSS attacks on cookies (https://techblog.topdesk.com/security/cookie-security/).

Bento found another issue with your test file (tests/test_app.py:102). You probably wanted to write `except AssertionError as e`. But I kept it out of this PR to keep things simple. In case you are curious, you can check it out using bento (download it from https://bento.dev)


