### PR TITLE
Req version bump so that it is compatible with latest debugtoolbar

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Flask==1.0.2
-flask-debugtoolbar==0.10.1
+flask-debugtoolbar>=0.11.0
 future==0.17.1
 pytest


### PR DESCRIPTION
flask-debugtoolbar>=0.11.0 from 10 so that it is compatible with debugtoolbar